### PR TITLE
Fix compiling on Kernel 6.15 (removal of EXTRA_CFLAGS)

### DIFF
--- a/applesmc/Makefile
+++ b/applesmc/Makefile
@@ -4,7 +4,7 @@ obj-m      += applesmc.o
 KVER       ?= `uname -r`
 KBASE      ?= /lib/modules/$(KVER)
 KBUILD_DIR ?= $(KBASE)/build
-EXTRA_CFLAGS := -I$(M)/sbs
+ccflags-y  := -I$(M)/sbs
 
 all:
 	make -C $(KBUILD_DIR) M=`pwd`


### PR DESCRIPTION
In kernel 6.15 variable EXTRA_CFLAGS is removed, so build is broken on this version. It should be replaced with ccflags-y.

This should fix https://github.com/c---/applesmc-next/issues/9