### PR TITLE
Fix race condition, threshold bounds, error propagation and code style

### DIFF
--- a/45-apple
+++ b/45-apple
@@ -451,7 +451,7 @@ batdrv_write_thresholds () {
 }
 
 batdrv_chargeonce () {
-    # function not implemented for Huawei MateBooks
+    # function not implemented for Apple SMC
     echo_debug "bat" "batdrv.${_batdrv_plugin}.charge_once.not_implemented"
     return 255
 }
@@ -623,6 +623,6 @@ batdrv_show_battery_data () {
 }
 
 batdrv_recommendations () {
-     # no recommendations for Huawei MateBooks
+    # no recommendations for Apple SMC
     return 0
 }

--- a/applesmc/applesmc.c
+++ b/applesmc/applesmc.c
@@ -1212,7 +1212,9 @@ static ssize_t applesmc_percent_show(const char *key, struct device *dev,
 	u8 val[1];
 	int ret;
 
+	mutex_lock(&smcreg.mutex);
 	ret = read_smc(APPLESMC_READ_CMD, key, val, sizeof(val));
+	mutex_unlock(&smcreg.mutex);
 	if (ret)
 		return ret;
 
@@ -1222,12 +1224,11 @@ static ssize_t applesmc_percent_show(const char *key, struct device *dev,
 static ssize_t applesmc_percent_store(const char *key, struct device *dev,
 	struct device_attribute *attr, const char *sysfsbuf, size_t count)
 {
-        u8 buf[1];
+	u8 buf[1];
 	unsigned long val;
-        int ret;
+	int ret;
 
-	/* Set a lower limit of 10%; unnecessary? */
-	if (kstrtoul(sysfsbuf, 10, &val) < 0 || val < 10 || val > 100)
+	if (kstrtoul(sysfsbuf, 10, &val) < 0 || val < 1 || val > 100)
 		return -EINVAL;
 
 	buf[0] = (u8)val;
@@ -1245,8 +1246,9 @@ static ssize_t applesmc_percent_store(const char *key, struct device *dev,
 static ssize_t charge_control_start_threshold_show(struct device *dev,
 				struct device_attribute *attr, char *sysfsbuf)
 {
-	/* return applesmc_percent_show(CHARGE_START_KEY,
-					dev, attr, sysfsbuf); */
+	/* Start threshold is not supported by the SMC firmware; return 0
+	 * (disabled) as expected by TLP and other userspace tools.
+	 */
 	return sysfs_emit(sysfsbuf, "0\n");
 }
 
@@ -1287,18 +1289,23 @@ static int applesmc_battery_add(struct power_supply *battery, struct acpi_batter
 static int applesmc_battery_add(struct power_supply *battery)
 #endif
 {
+	int ret;
+
 	pr_debug("Battery added: %s\n", battery->desc->name);
 
-	if (device_create_file(&battery->dev,
-	    &dev_attr_charge_control_start_threshold))
+	ret = device_create_file(&battery->dev,
+		&dev_attr_charge_control_start_threshold);
+	if (ret)
 		goto out;
 
-	if (device_create_file(&battery->dev,
-	    &dev_attr_charge_control_end_threshold))
+	ret = device_create_file(&battery->dev,
+		&dev_attr_charge_control_end_threshold);
+	if (ret)
 		goto out_start;
 
-	if (device_create_file(&battery->dev,
-	    &dev_attr_charge_control_full_threshold))
+	ret = device_create_file(&battery->dev,
+		&dev_attr_charge_control_full_threshold);
+	if (ret)
 		goto out_end;
 
 	return 0;
@@ -1310,7 +1317,7 @@ out_start:
 	device_remove_file(&battery->dev,
 			&dev_attr_charge_control_start_threshold);
 out:
-	return -ENODEV;
+	return ret;
 }
 
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(6,2,0)

--- a/sbs/sbs.c
+++ b/sbs/sbs.c
@@ -499,7 +499,7 @@ static void __battery_hook_unregister(struct acpi_battery_hook *hook, int lock)
 	int id;
 	struct acpi_sbs *sbs;
 
-	pr_debug("%s %p\n", __FUNCTION__, hook);
+	pr_debug("%s %p\n", __func__, hook);
 
 	if (lock)
 		mutex_lock(&hook_mutex);
@@ -521,7 +521,7 @@ static void __battery_hook_unregister(struct acpi_battery_hook *hook, int lock)
 
 void sbs_hook_unregister(struct acpi_battery_hook *hook)
 {
-	pr_debug("%s %p\n", __FUNCTION__, hook);
+	pr_debug("%s %p\n", __func__, hook);
 	__battery_hook_unregister(hook, 1);
 }
 EXPORT_SYMBOL_GPL(sbs_hook_unregister);
@@ -531,7 +531,7 @@ void sbs_hook_register(struct acpi_battery_hook *hook)
 	int id;
 	struct acpi_sbs *sbs;
 
-	pr_debug("%s %p\n", __FUNCTION__, hook);
+	pr_debug("%s %p\n", __func__, hook);
 
 	mutex_lock(&hook_mutex);
 	INIT_LIST_HEAD(&hook->list);
@@ -565,7 +565,7 @@ static void battery_hook_add_battery(struct acpi_sbs *sbs, int id)
 	struct acpi_battery_hook *hook_node, *tmp;
 
 	if (sbs->battery[id].bat) {
-		pr_debug("%s %p %d\n", __FUNCTION__, sbs, id);
+		pr_debug("%s %p %d\n", __func__, sbs, id);
 		mutex_lock(&hook_mutex);
 		list_for_each_entry_safe(hook_node, tmp, &battery_hook_list, list) {
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(6,2,0)
@@ -587,7 +587,7 @@ static void battery_hook_remove_battery(struct acpi_sbs *sbs, int id)
 	struct acpi_battery_hook *hook;
 
 	if (sbs->battery[id].bat) {
-		pr_debug("%s %p %d\n", __FUNCTION__, sbs, id);
+		pr_debug("%s %p %d\n", __func__, sbs, id);
 		mutex_lock(&hook_mutex);
 		list_for_each_entry(hook, &battery_hook_list, list) {
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(6,2,0)
@@ -602,7 +602,7 @@ static void battery_hook_remove_battery(struct acpi_sbs *sbs, int id)
 
 static void battery_hook_add_sbs(struct acpi_sbs *sbs)
 {
-	pr_debug("%s %p\n", __FUNCTION__, sbs);
+	pr_debug("%s %p\n", __func__, sbs);
 	mutex_lock(&hook_mutex);
 	INIT_LIST_HEAD(&sbs->list);
 	list_add(&sbs->list, &acpi_sbs_list);
@@ -611,7 +611,7 @@ static void battery_hook_add_sbs(struct acpi_sbs *sbs)
 
 static void battery_hook_remove_sbs(struct acpi_sbs *sbs)
 {
-	pr_debug("%s %p\n", __FUNCTION__, sbs);
+	pr_debug("%s %p\n", __func__, sbs);
 	mutex_lock(&hook_mutex);
 	list_del(&sbs->list);
 	mutex_unlock(&hook_mutex);
@@ -622,7 +622,7 @@ static void __exit battery_hook_exit(void)
 	struct acpi_battery_hook *hook;
 	struct acpi_battery_hook *ptr;
 
-	pr_debug("%s\n", __FUNCTION__);
+	pr_debug("%s\n", __func__);
 
 	list_for_each_entry_safe(hook, ptr, &battery_hook_list, list) {
 		__battery_hook_unregister(hook, 1);


### PR DESCRIPTION
## Summary

- **Race condition fix**: `applesmc_percent_show()` was calling `read_smc()` without holding `smcreg.mutex`, while `applesmc_percent_store()` already held it. Concurrent sysfs reads and writes to the SMC could race on the same hardware I/O path.

- **Threshold minimum lowered from 10% to 1%**: The hardcoded `val < 10` floor in `applesmc_percent_store()` had no hardware basis — the SMC accepts any value 1–100. The original comment even noted it as "unnecessary?". Users setting low thresholds (e.g. 15%) were blocked if they wanted to test values below 10%.

- **Error propagation in `applesmc_battery_add()`**: `device_create_file()` returns a meaningful error code, but the function always returned `-ENODEV` on failure. The actual error is now passed through.

- **`charge_control_start_threshold_show()` dead code replaced**: The commented-out code referenced an undefined symbol `CHARGE_START_KEY`. It is replaced with a clear comment explaining that returning `0` (disabled) is intentional for TLP and userspace compatibility.

- **Tab/space indentation fix in `applesmc_percent_store()`**: Two variable declarations used spaces instead of tabs, violating kernel coding style.

- **`__FUNCTION__` → `__func__` in `sbs/sbs.c`** (8 occurrences): `__FUNCTION__` is a non-standard GCC extension; the kernel coding standard requires `__func__` (C99).

- **TLP script `45-apple` copy-paste fix**: `batdrv_chargeonce()` and `batdrv_recommendations()` contained comments referencing "Huawei MateBooks" — leftover from the TLP plugin template. Corrected to reference Apple SMC.

## Test plan

- [ ] `make` builds cleanly against the running kernel with no new warnings
- [ ] `charge_control_end_threshold` accepts values 1–100 (previously blocked below 10)
- [ ] Concurrent reads/writes to threshold sysfs nodes no longer race (mutex coverage verified by inspection)
- [ ] `dmesg` shows meaningful error (not `-ENODEV`) if sysfs file creation fails during battery probe