### PR TITLE
sbs: fix probe on kernels with platform-driver sbshc

### DIFF
--- a/sbs/sbs.c
+++ b/sbs/sbs.c
@@ -797,7 +797,21 @@ static int acpi_sbs_add(struct acpi_device *device)
 	mutex_init(&sbs->lock);
 
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(6,1,0)
-	sbs->hc = acpi_driver_data(acpi_dev_parent(device));
+	{
+		/*
+		 * Modern Ubuntu/upstream kernels convert sbshc to a
+		 * platform_driver, so the host-controller pointer lives
+		 * in the parent's platform device drvdata, not its ACPI
+		 * driver_data. Try the platform path first, fall back to
+		 * the legacy ACPI driver_data path.
+		 */
+		struct acpi_device *parent_adev = acpi_dev_parent(device);
+		struct device *parent_pdev = parent_adev ?
+				acpi_get_first_physical_node(parent_adev) : NULL;
+		sbs->hc = parent_pdev ? dev_get_drvdata(parent_pdev) : NULL;
+		if (!sbs->hc && parent_adev)
+			sbs->hc = acpi_driver_data(parent_adev);
+	}
 #else
 	sbs->hc = acpi_driver_data(device->parent);
 #endif
@@ -805,6 +819,11 @@ static int acpi_sbs_add(struct acpi_device *device)
 	strcpy(acpi_device_name(device), ACPI_SBS_DEVICE_NAME);
 	strcpy(acpi_device_class(device), ACPI_SBS_CLASS);
 	device->driver_data = sbs;
+
+	if (!sbs->hc) {
+		result = -EPROBE_DEFER;
+		goto end;
+	}
 
 	result = acpi_charger_add(sbs);
 	if (result && result != -ENODEV)
@@ -855,7 +874,8 @@ static int acpi_sbs_remove(struct acpi_device *device)
 		return -EINVAL;
 #endif
 	mutex_lock(&sbs->lock);
-	acpi_smbus_unregister_callback(sbs->hc);
+	if (sbs->hc)
+		acpi_smbus_unregister_callback(sbs->hc);
 	for (id = 0; id < MAX_SBS_BAT; ++id)
 		acpi_battery_remove(sbs, id);
 	acpi_charger_remove(sbs);


### PR DESCRIPTION
## Summary

On recent Ubuntu kernels (notably 26.04 Resolute's 7.0 series), `sbshc` was converted from `acpi_driver` to `platform_driver`. As a result, `acpi_driver_data(acpi_dev_parent(device))` in `acpi_sbs_add()` returns NULL, the probe charges into `acpi_charger_add()` (whose helpers dereference `hc`), and the cleanup path then oopses on `acpi_smbus_unregister_callback(NULL)`:

```
BUG: kernel NULL pointer dereference, address: 0x0000000000000008
RIP: 0010:mutex_lock+0x1c/0x50
Call Trace:
 acpi_smbus_unregister_callback+0x18/0x50 [sbshc]
 acpi_sbs_remove+0x4f/0x280 [sbs]
 acpi_sbs_add+0x17e/0x380 [sbs]
```

The half-loaded `sbs` is then unrecoverable until reboot (`MODULE_STATE_COMING`, no FORCE_UNLOAD on Ubuntu).

## Fix

1. Resolve `hc` via `acpi_get_first_physical_node()` + `dev_get_drvdata()` on the platform device, with a fallback to the legacy `acpi_driver_data()` path for older kernels where sbshc is still an `acpi_driver`.
2. Bail with `-EPROBE_DEFER` if `hc` still cannot be resolved instead of crashing.
3. NULL-check `sbs->hc` before `acpi_smbus_unregister_callback()` in the remove path, so any future failure path that leaves `hc` unset cleans up safely.

## Test plan

- [x] Loads cleanly on Ubuntu 26.04 / kernel 7.0.0-14-generic / MacBookPro9,2
- [x] `/sys/class/power_supply/BAT0/charge_control_end_threshold` appears
- [x] `echo 80 > charge_control_end_threshold` is read back as `80` and the BCLM SMC key is written
- [x] No oops or taint beyond the expected OOT module taint